### PR TITLE
chore: Use ubuntu-20.04 for nuget deployment

### DIFF
--- a/build/steps-release.yml
+++ b/build/steps-release.yml
@@ -1,6 +1,8 @@
 jobs:
 - deployment: Publish_Nuget
   environment: Nuget
+  pool:
+      vmImage: 'ubuntu-20.04'
   strategy:
     runOnce:
       deploy:


### PR DESCRIPTION
Deployment to nuget currently fails because it tries to access vm image ubuntu-16.04, which was removed in 2021. This PR migrates the deployment process to the ubuntu-20.04 Microsoft hosted image.