### PR TITLE
chore: Fix the artifact deployment to nuget

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -13,6 +13,7 @@ variables:
   PackageOutputPath: $(Build.ArtifactStagingDirectory)
   NUGET_VERSION: 6.5.0
   macPoolName: 'macOS-12'
+  ArtifactName: Binding.Intercom
 
 stages:
 - stage: Build
@@ -24,7 +25,6 @@ stages:
       matrix:
         Binding.Intercom:
           ApplicationPlatform: Any CPU
-          ArtifactName: Binding.Intercom
 
     pool:
       vmImage: $(macPoolName)

--- a/build/steps-release.yml
+++ b/build/steps-release.yml
@@ -8,14 +8,14 @@ jobs:
       deploy:
         steps:
           - download: current
-            artifact: Binding.Intercom
+            artifact: $(ArtifactName)
 
           - task: NuGetCommand@2
             displayName: 'Publish nuget package'
             inputs:
               command: push
               nuGetFeedType: external
-              packagesToPush: '$(build.ArtifactStagingDirectory)/**/*.nupkg'
+              packagesToPush: '$(Pipeline.Workspace)/**/*.nupkg'
               publishFeedCredentials: 'NuGet.org - nventive'
               verbosityPush: Normal
 


### PR DESCRIPTION
Fix the artifact deployment to nuget, as the previous PR to update the Binding to .net 7 built successfully but the deploy stage didn't find the nuget packages to deploy. Reverting the yaml to its previous value to fix this step.