### PR TITLE
fix: Make sure native library is included in iOS package

### DIFF
--- a/Binding.Intercom.iOS/Binding.Intercom.iOS.csproj
+++ b/Binding.Intercom.iOS/Binding.Intercom.iOS.csproj
@@ -29,6 +29,16 @@
 			<ForceLoad>True</ForceLoad>
 			<LinkerFlags>-ObjC</LinkerFlags>
 		</NativeReference>
+
+		<Content Include="manifest">
+			<Pack>true</Pack>
+			<PackagePath>lib\net7.0-ios16.1\Binding.Intercom.iOS.resources</PackagePath>
+		</Content>
+
+		<Content Include="Intercom.framework\**">
+			<Pack>true</Pack>
+			<PackagePath>lib\net7.0-ios16.1\Binding.Intercom.iOS.resources\Intercom.framework</PackagePath>
+		</Content>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Binding.Intercom.iOS/Readme.md
+++ b/Binding.Intercom.iOS/Readme.md
@@ -1,0 +1,3 @@
+﻿The manifest file is included to compensate for differences between compilation on a Windows machine, where it's not included in the nuget package, and compilation on a Mac machine, where it is included.
+
+When updating the native library, make sure to also update the manifest file by copying it from the output folder, after building on a Mac.

--- a/Binding.Intercom.iOS/manifest
+++ b/Binding.Intercom.iOS/manifest
@@ -1,0 +1,12 @@
+﻿<BindingAssembly>
+	<NativeReference Name="Intercom.framework">
+		<ForceLoad>True</ForceLoad>
+		<Frameworks>Foundation</Frameworks>
+		<IsCxx></IsCxx>
+		<Kind>Framework</Kind>
+		<LinkerFlags>-ObjC</LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<SmartLink></SmartLink>
+		<WeakFrameworks></WeakFrameworks>
+	</NativeReference>
+</BindingAssembly>


### PR DESCRIPTION
In the reformatting of the library to target .NET 7 instead of Xamarin, the iOS nuget package wasn't correctly including the native library. This PR fixes this by explicitly including those files in the package.