### PR TITLE
chore: Don't create new versions of packages which haven't changed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+GitHub Issue: #
+
+## PR Type
+
+What kind of change does this PR introduce?
+<!-- Please uncomment one or more that apply to this PR -->
+
+- Bugfix
+- Feature
+- Code style update (formatting)
+- Refactoring (no functional changes, no api changes)
+- Build or CI related changes
+- Documentation content changes
+- Other... Please describe:
+
+
+## Description
+
+<!-- (Please describe the changes that this PR introduces.) -->
+
+
+## PR Checklist 
+Please check if your PR fulfills the following requirements:
+
+- [ ] `GeneratePackageOnBuild` set to True for all packages which have changed (except Binding.Intercom.Xamarin) and False to all packages which have not
+- [ ] Tested on all relevant platforms
+
+
+## Other information
+
+<!-- Please provide any additional information if necessary -->

--- a/Binding.Intercom.Android.Base/Binding.Intercom.Android.Base.csproj
+++ b/Binding.Intercom.Android.Base/Binding.Intercom.Android.Base.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.intercom.android</PackageId>

--- a/Binding.Intercom.Android.Commons/Binding.Intercom.Android.Commons.csproj
+++ b/Binding.Intercom.Android.Commons/Binding.Intercom.Android.Commons.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.android.commons</PackageId>

--- a/Binding.Intercom.Android.Composer.Gallery/Binding.Intercom.Android.Composer.Gallery.csproj
+++ b/Binding.Intercom.Android.Composer.Gallery/Binding.Intercom.Android.Composer.Gallery.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.android.composer.gallery</PackageId>

--- a/Binding.Intercom.Android.Composer/Binding.Intercom.Android.Composer.csproj
+++ b/Binding.Intercom.Android.Composer/Binding.Intercom.Android.Composer.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.android.composer</PackageId>

--- a/Binding.Intercom.Android.Fcm/Binding.Intercom.Android.Fcm.csproj
+++ b/Binding.Intercom.Android.Fcm/Binding.Intercom.Android.Fcm.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.intercom.fcm</PackageId>

--- a/Binding.Intercom.AndroidX.DataBinding.ViewBinding/Binding.Intercom.AndroidX.DataBinding.ViewBinding.csproj
+++ b/Binding.Intercom.AndroidX.DataBinding.ViewBinding/Binding.Intercom.AndroidX.DataBinding.ViewBinding.csproj
@@ -5,7 +5,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Version>7.1.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Binding.Intercom.Facebook.Flipper/Binding.Intercom.Facebook.Flipper.csproj
+++ b/Binding.Intercom.Facebook.Flipper/Binding.Intercom.Facebook.Flipper.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.facebook.flipper</PackageId>

--- a/Binding.Intercom.Io.Coil.Compose.Base/Binding.Intercom.Io.Coil.Compose.Base.csproj
+++ b/Binding.Intercom.Io.Coil.Compose.Base/Binding.Intercom.Io.Coil.Compose.Base.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.io.coil.compose.base</PackageId>

--- a/Binding.Intercom.Io.Coil.Compose/Binding.Intercom.Io.Coil.Compose.csproj
+++ b/Binding.Intercom.Io.Coil.Compose/Binding.Intercom.Io.Coil.Compose.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.io.coil.compose</PackageId>

--- a/Binding.Intercom.Io.Coil.Gif/Binding.Intercom.Io.Coil.Gif.csproj
+++ b/Binding.Intercom.Io.Coil.Gif/Binding.Intercom.Io.Coil.Gif.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.io.coil.gif</PackageId>

--- a/Binding.Intercom.Io.Coil.Video/Binding.Intercom.Io.Coil.Video.csproj
+++ b/Binding.Intercom.Io.Coil.Video/Binding.Intercom.Io.Coil.Video.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.io.coil.video</PackageId>

--- a/Binding.Intercom.Io.CoilKt.Base/Binding.Intercom.Io.CoilKt.Base.csproj
+++ b/Binding.Intercom.Io.CoilKt.Base/Binding.Intercom.Io.CoilKt.Base.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.io.coilkt.base</PackageId>

--- a/Binding.Intercom.Kotlinx.Serialization.Core.Jvm/Binding.Intercom.Kotlinx.Serialization.Core.Jvm.csproj
+++ b/Binding.Intercom.Kotlinx.Serialization.Core.Jvm/Binding.Intercom.Kotlinx.Serialization.Core.Jvm.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.kotlinx.serialization.core.jvm</PackageId>

--- a/Binding.Intercom.Kotlinx.Serialization.Json.Jvm/Binding.Intercom.Kotlinx.Serialization.Json.Jvm.csproj
+++ b/Binding.Intercom.Kotlinx.Serialization.Json.Jvm/Binding.Intercom.Kotlinx.Serialization.Json.Jvm.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.kotlinx.serialization.json.jvm</PackageId>

--- a/Binding.Intercom.Kotlinx.Serialization.Json/Binding.Intercom.Kotlinx.Serialization.Json.csproj
+++ b/Binding.Intercom.Kotlinx.Serialization.Json/Binding.Intercom.Kotlinx.Serialization.Json.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.kotlinx.serialization.json</PackageId>

--- a/Binding.Intercom.Nexus/Binding.Intercom.Nexus.csproj
+++ b/Binding.Intercom.Nexus/Binding.Intercom.Nexus.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.nexus</PackageId>

--- a/Binding.Intercom.Retrofit.Converter.Gson/Binding.Intercom.Retrofit.Converter.Gson.csproj
+++ b/Binding.Intercom.Retrofit.Converter.Gson/Binding.Intercom.Retrofit.Converter.Gson.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.retrofit.converter.gson</PackageId>

--- a/Binding.Intercom.Retrofit2.Serialization.Converter/Binding.Intercom.Retrofit2.Serialization.Converter.csproj
+++ b/Binding.Intercom.Retrofit2.Serialization.Converter/Binding.Intercom.Retrofit2.Serialization.Converter.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.retrofit2</PackageId>

--- a/Binding.Intercom.SquareUp.Otto/Binding.Intercom.SquareUp.Otto.csproj
+++ b/Binding.Intercom.SquareUp.Otto/Binding.Intercom.SquareUp.Otto.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.otto</PackageId>

--- a/Binding.Intercom.Twig/Binding.Intercom.Twig.csproj
+++ b/Binding.Intercom.Twig/Binding.Intercom.Twig.csproj
@@ -4,7 +4,7 @@
 		<SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>nventive.binding.twig</PackageId>

--- a/Binding.Intercom.Xamarin/Binding.Intercom.Xamarin.csproj
+++ b/Binding.Intercom.Xamarin/Binding.Intercom.Xamarin.csproj
@@ -3,6 +3,7 @@
 		<TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<!--This property must always remain false, or else the build fails.-->
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 

--- a/Binding.Intercom.iOS/Binding.Intercom.iOS.csproj
+++ b/Binding.Intercom.iOS/Binding.Intercom.iOS.csproj
@@ -16,6 +16,7 @@
 		<PackageIcon>nugetIcon.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/nventive/Binding.Intercom</PackageProjectUrl>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<Version>9.3.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
The deployment of the new version of the package has failed because it tried to update to nuget new versions of the sub-packages with the same version. This PR makes sure not to generate new nuget packages for projects which haven't changed.

In future, when we want to update packages, we'll need to update both their version number and <GeneratePackageOnBuild> to make sure these packages, and only these packages, are updated.